### PR TITLE
🐞 Bug: Persist Craftan Jar in Docker-Compose

### DIFF
--- a/.idea/runConfigurations/Build_Jar.xml
+++ b/.idea/runConfigurations/Build_Jar.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build Jar" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="task build" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Start_server.xml
+++ b/.idea/runConfigurations/Start_server.xml
@@ -4,9 +4,11 @@
       <settings>
         <option name="envFilePath" value="" />
         <option name="commandLineOptions" value="--build" />
-        <option name="sourceFilePath" value="docker-compose.yml" />
+        <option name="sourceFilePath" value="deployment/docker-compose.yml" />
       </settings>
     </deployment>
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Build Jar" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,9 @@ tasks:
   # build
   build:
     cmds:
-      - ./gradlew build --parallel
+      - ./gradlew clean build --parallel
+      - mkdir -p ./deployment/build
+      - cp ./build/libs/Craftan-*-all.jar ./deployment/build/craftan.jar
 
   # docker
   docker:build:
@@ -21,6 +23,7 @@ tasks:
         .
   docker-compose:up:
     cmds:
+      - task: build
       - >
         docker compose
         --file ./deployment/docker-compose.yml

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - "25565:25565"
       - "5005:5005"
     volumes:
-      - craftan-server:/app
+      - "${PWD}/deployment/build/craftan.jar:/app/plugins/craftan.jar"


### PR DESCRIPTION
## Description

The built plugin is not actually the executed one in the container.
To refresh it, the volume needs to be erased.

## Task

- [x] persist `craftan.jar`