### PR TITLE
✨ Feature: Add MariaDB Docker Service with Persistent Data Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,20 @@
-# Gradle
-.gradle
+# Development
+## Docker Compose
+deployment/database/
+## Environment Variables
+.env
+## Gradle
+.gradle/
 build/
-!gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+!gradle/wrapper/gradle-wrapper.jar
 local.properties
-
-# Environment
-.env
-
-# IntelliJ IDEA
+## IDE
+.vscode/
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 .idea/compiler.xml
 .idea/jarRepositories.xml
 .idea/libraries/
@@ -17,34 +22,9 @@ local.properties
 *.iml
 *.ipr
 *.iws
-out/
-!**/src/main/**/out/
-!**/src/test/**/out/
-
-# Eclipse
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
-.sts4-cache
-bin/
-!**/src/main/**/bin/
-!**/src/test/**/bin/
-
-# NetBeans
-/.nb-gradle/
-/dist/
-/nbbuild/
-/nbdist/
-/nbproject/private/
-
-# VS Code
-.vscode/
-
-# Mac OS
-.DS_Store
-
-# Taskfile
+## Taskfile Cache
 .task/
+
+# Operating System
+## MacOS
+.DS_Store

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,14 +1,46 @@
-volumes:
-  craftan-server:
+networks:
+  craftan-network:
+    driver: bridge
 
 services:
+  mariadb:
+    image: bitnami/mariadb:11.5
+    environment:
+      MARIADB_DATABASE: "${MARIADB_DATABASE:-craftandatabase}"
+      MARIADB_PASSWORD: "${MARIADB_PASSWORD:-craftanpassword}"
+      MARIADB_ROOT_PASSWORD: "${MARIADB_ROOT_PASSWORD:-craftanrootpassword}"
+      MARIADB_USER: "${MARIADB_USER:-craftanuser}"
+    healthcheck:
+      interval: 15s
+      retries: 6
+      start_period: 10s
+      test: ["CMD", "/opt/bitnami/scripts/mariadb/healthcheck.sh"]
+      timeout: 5s
+    networks:
+      - craftan-network
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+    volumes:
+      - "${PWD}/deployment/database/mariadb:/bitnami/mariadb"
+
   paper-server:
     build:
       context: ..
       dockerfile: ./deployment/Dockerfile
-    restart: unless-stopped
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      CT_MARIADB_DATABASE: "${MARIADB_DATABASE:-craftandatabase}"
+      CT_MARIADB_HOST: "${MARIADB_HOST:-mariadb}"
+      CT_MARIADB_PASSWORD: "${MARIADB_PASSWORD:-craftanpassword}"
+      CT_MARIADB_USER: "${MARIADB_USER:-craftanuser}"
+    networks:
+      - craftan-network
     ports:
       - "25565:25565"
       - "5005:5005"
+    restart: unless-stopped
     volumes:
       - "${PWD}/deployment/build/craftan.jar:/app/plugins/craftan.jar"


### PR DESCRIPTION
## Description

This merge request adds a MariaDB Docker service to the existing Docker Compose setup for the Craftan project. The MariaDB service is configured with persistent data storage to ensure that database data is retained across container restarts and updates.

## Task

- [x] Add a MariaDB service to docker-compose.yml with appropriate environment variables for database configuration.
  - [ ] Verify that the environment variables assigned to the Paper server are appropriately named and adhere to the project's naming conventions.
- [x] Configure persistent data storage for the MariaDB service.
- [x] Update `.gitignore` to include Docker Compose and environment variable files.

## Checklist (Optional)

- [x] Verify the Docker Compose setup with the new MariaDB service.
- [ ] Ensure that the MariaDB service starts correctly and is accessible by the Paper server.
- [x] Test persistent data storage functionality.

